### PR TITLE
Support Multiple Values for Same Operator in OR/NOT Filters

### DIFF
--- a/docs/advanced/filters.md
+++ b/docs/advanced/filters.md
@@ -32,6 +32,29 @@ results = await crud.get_multi(
 # Generates: WHERE age < 18 OR age > 65
 ```
 
+You can also provide a list of values for the same operator to create multiple OR conditions:
+
+```python
+# Find users with names starting with Alice OR Frank OR Bob
+results = await crud.get_multi(
+    db,
+    name__or={
+        "like": ["Alice%", "Frank%", "Bob%"]
+    }
+)
+# Generates: WHERE name LIKE 'Alice%' OR name LIKE 'Frank%' OR name LIKE 'Bob%'
+
+# Mix list and single values in OR conditions
+results = await crud.get_multi(
+    db,
+    name__or={
+        "like": ["Alice%", "Frank%"],  # List of patterns
+        "startswith": "Bob"             # Single value
+    }
+)
+# Generates: WHERE name LIKE 'Alice%' OR name LIKE 'Frank%' OR name STARTSWITH 'Bob'
+```
+
 ### Multi-Field OR
 
 Use the special `_or` parameter to apply OR conditions across multiple different fields:
@@ -66,6 +89,19 @@ results = await crud.get_multi(
 # Generates: WHERE NOT age = 20 AND NOT (age BETWEEN 30 AND 40)
 ```
 
+Similar to OR operations, you can provide a list of values for the same operator in NOT conditions:
+
+```python
+# Find users whose names do NOT start with Alice, Frank, or Bob
+results = await crud.get_multi(
+    db,
+    name__not={
+        "like": ["Alice%", "Frank%", "Bob%"]
+    }
+)
+# Generates: WHERE NOT (name LIKE 'Alice%') AND NOT (name LIKE 'Frank%') AND NOT (name LIKE 'Bob%')
+```
+
 ## Supported Operators
 
 - Comparison: `eq`, `gt`, `lt`, `gte`, `lte`, `ne`
@@ -95,6 +131,23 @@ results = await crud.get_multi(
     name__or={
         "startswith": "A",
         "endswith": "smith"
+    }
+)
+
+# Search for multiple patterns with LIKE operator
+results = await crud.get_multi(
+    db,
+    name__or={
+        "like": ["Alice%", "Bob%", "Charlie%"]
+    }
+)
+
+# Combine multiple operators including lists
+results = await crud.get_multi(
+    db,
+    email__or={
+        "ilike": ["%gmail.com", "%yahoo.com"],  # Multiple email domains
+        "endswith": ".edu"                      # OR educational emails
     }
 )
 

--- a/tests/sqlalchemy/crud/test_get_multi.py
+++ b/tests/sqlalchemy/crud/test_get_multi.py
@@ -291,7 +291,7 @@ async def test_get_multi_or_filtering(async_session, test_model):
     crud = FastCRUD(test_model)
 
     # Test OR with simple conditions on tier_id
-    result = await crud.get_multi(async_session, tier_id__or={"eq": 1, "eq": 6})
+    result = await crud.get_multi(async_session, tier_id__or={"eq": [1, 6]})
     assert len(result["data"]) > 0
     assert all(item["tier_id"] in [1, 6] for item in result["data"])
 
@@ -302,7 +302,7 @@ async def test_get_multi_or_filtering(async_session, test_model):
 
     # Test OR with like conditions on name
     result = await crud.get_multi(
-        async_session, name__or={"like": "Alice%", "like": "Frank%"}
+        async_session, name__or={"like": ["Alice%", "Frank%"]}
     )
     assert len(result["data"]) > 0
     assert all(

--- a/tests/sqlalchemy/crud/test_multiple_like_or.py
+++ b/tests/sqlalchemy/crud/test_multiple_like_or.py
@@ -1,0 +1,201 @@
+import pytest
+from fastcrud import FastCRUD
+
+
+@pytest.mark.asyncio
+async def test_or_filter_with_multiple_like_values(async_session, test_model):
+    """Test OR filter with multiple values for the same operator (like)"""
+    # Create test data
+    test_data = [
+        {"name": "Alice Johnson", "tier_id": 1, "category_id": 1},
+        {"name": "Bob Smith", "tier_id": 2, "category_id": 1},
+        {"name": "Charlie Brown", "tier_id": 3, "category_id": 2},
+        {"name": "Frank Miller", "tier_id": 4, "category_id": 2},
+        {"name": "Alice Cooper", "tier_id": 5, "category_id": 1},
+        {"name": "Frank Sinatra", "tier_id": 6, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Test with multiple like patterns using list syntax
+    result = await crud.get_multi(
+        async_session, name__or={"like": ["Alice%", "Frank%"]}
+    )
+
+    assert (
+        len(result["data"]) == 4
+    )  # Alice Johnson, Alice Cooper, Frank Miller, Frank Sinatra
+    names = [item["name"] for item in result["data"]]
+    assert all(name.startswith("Alice") or name.startswith("Frank") for name in names)
+
+    # Test with case-insensitive multiple patterns
+    result = await crud.get_multi(
+        async_session, name__or={"ilike": ["%cooper", "%sinatra"]}
+    )
+
+    assert len(result["data"]) == 2
+    names = [item["name"] for item in result["data"]]
+    assert "Alice Cooper" in names
+    assert "Frank Sinatra" in names
+
+
+@pytest.mark.asyncio
+async def test_or_filter_with_multiple_operators_including_lists(
+    async_session, test_model
+):
+    """Test OR filter mixing single values and lists"""
+    test_data = [
+        {"name": "Alice Johnson", "tier_id": 1, "category_id": 1},
+        {"name": "Bob Smith", "tier_id": 10, "category_id": 1},
+        {"name": "Charlie Brown", "tier_id": 3, "category_id": 2},
+        {"name": "Frank Miller", "tier_id": 4, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Mix list and single value in OR condition
+    result = await crud.get_multi(
+        async_session, name__or={"like": ["Alice%", "Frank%"], "startswith": "Bob"}
+    )
+
+    assert len(result["data"]) == 3
+    names = [item["name"] for item in result["data"]]
+    assert "Alice Johnson" in names
+    assert "Bob Smith" in names
+    assert "Frank Miller" in names
+
+
+@pytest.mark.asyncio
+async def test_not_filter_with_multiple_like_values(async_session, test_model):
+    """Test NOT filter with multiple values for the same operator"""
+    test_data = [
+        {"name": "Alice Johnson", "tier_id": 1, "category_id": 1},
+        {"name": "Bob Smith", "tier_id": 2, "category_id": 1},
+        {"name": "Charlie Brown", "tier_id": 3, "category_id": 2},
+        {"name": "David Jones", "tier_id": 4, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Test NOT filter with multiple like patterns
+    result = await crud.get_multi(async_session, name__not={"like": ["Alice%", "Bob%"]})
+
+    assert len(result["data"]) == 2
+    names = [item["name"] for item in result["data"]]
+    assert "Charlie Brown" in names
+    assert "David Jones" in names
+    assert "Alice Johnson" not in names
+    assert "Bob Smith" not in names
+
+
+@pytest.mark.asyncio
+async def test_or_filter_with_contains_operator_list(async_session, test_model):
+    """Test OR filter with multiple contains values"""
+    test_data = [
+        {"name": "Alice Johnson", "tier_id": 1, "category_id": 1},
+        {"name": "Bob Smith", "tier_id": 2, "category_id": 1},
+        {"name": "Charlie Brown", "tier_id": 3, "category_id": 2},
+        {"name": "David Jones", "tier_id": 4, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Test with multiple contains patterns
+    result = await crud.get_multi(
+        async_session, name__or={"contains": ["John", "Smith", "Jones"]}
+    )
+
+    assert len(result["data"]) == 3
+    names = [item["name"] for item in result["data"]]
+    assert "Alice Johnson" in names  # Contains "John"
+    assert "Bob Smith" in names  # Contains "Smith"
+    assert "David Jones" in names  # Contains "Jones"
+    assert "Charlie Brown" not in names
+
+
+@pytest.mark.asyncio
+async def test_combined_filters_with_list_or(async_session, test_model):
+    """Test combining regular filters with list-based OR filters"""
+    test_data = [
+        {"name": "Alice Johnson", "tier_id": 1, "category_id": 1},
+        {"name": "Alice Cooper", "tier_id": 2, "category_id": 2},
+        {"name": "Bob Smith", "tier_id": 3, "category_id": 1},
+        {"name": "Frank Miller", "tier_id": 4, "category_id": 1},
+        {"name": "Frank Sinatra", "tier_id": 5, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Combine regular filter with list-based OR filter
+    result = await crud.get_multi(
+        async_session,
+        category_id=1,  # AND condition
+        name__or={"like": ["Alice%", "Frank%"]},  # OR condition with list
+    )
+
+    assert len(result["data"]) == 2
+    for item in result["data"]:
+        assert item["category_id"] == 1
+        assert item["name"].startswith("Alice") or item["name"].startswith("Frank")
+
+    names = [item["name"] for item in result["data"]]
+    assert "Alice Johnson" in names
+    assert "Frank Miller" in names
+    assert "Alice Cooper" not in names  # category_id=2
+    assert "Frank Sinatra" not in names  # category_id=2
+
+
+@pytest.mark.asyncio
+async def test_or_filter_with_in_operator_list(async_session, test_model):
+    """Test that 'in' operator still works with its expected list/tuple format"""
+    test_data = [
+        {"name": "Alice", "tier_id": 1, "category_id": 1},
+        {"name": "Bob", "tier_id": 2, "category_id": 1},
+        {"name": "Charlie", "tier_id": 3, "category_id": 2},
+        {"name": "David", "tier_id": 4, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Regular 'in' filter should still work
+    result = await crud.get_multi(async_session, name__in=["Alice", "Bob"])
+
+    assert len(result["data"]) == 2
+    names = [item["name"] for item in result["data"]]
+    assert "Alice" in names
+    assert "Bob" in names
+
+    # Test OR with 'in' operator (though 'in' already handles multiple values)
+    result = await crud.get_multi(
+        async_session,
+        tier_id__or={
+            "in": [[1, 2], [3, 4]]
+        },  # List of lists for multiple 'in' conditions
+    )
+
+    # This should match all tier_ids (1,2,3,4)
+    assert len(result["data"]) == 4

--- a/tests/sqlmodel/crud/test_multiple_like_or.py
+++ b/tests/sqlmodel/crud/test_multiple_like_or.py
@@ -1,0 +1,106 @@
+import pytest
+from fastcrud import FastCRUD
+
+
+@pytest.mark.asyncio
+async def test_or_filter_with_multiple_like_values_sqlmodel(async_session, test_model):
+    """Test OR filter with multiple values for the same operator (like) - SQLModel version"""
+    # Create test data
+    test_data = [
+        {"name": "Alice Johnson", "tier_id": 1, "category_id": 1},
+        {"name": "Bob Smith", "tier_id": 2, "category_id": 1},
+        {"name": "Charlie Brown", "tier_id": 3, "category_id": 2},
+        {"name": "Frank Miller", "tier_id": 4, "category_id": 2},
+        {"name": "Alice Cooper", "tier_id": 5, "category_id": 1},
+        {"name": "Frank Sinatra", "tier_id": 6, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Test with multiple like patterns using list syntax
+    result = await crud.get_multi(
+        async_session, name__or={"like": ["Alice%", "Frank%"]}
+    )
+
+    assert (
+        len(result["data"]) == 4
+    )  # Alice Johnson, Alice Cooper, Frank Miller, Frank Sinatra
+    names = [item["name"] for item in result["data"]]
+    assert all(name.startswith("Alice") or name.startswith("Frank") for name in names)
+
+    # Test with case-insensitive multiple patterns
+    result = await crud.get_multi(
+        async_session, name__or={"ilike": ["%cooper", "%sinatra"]}
+    )
+
+    assert len(result["data"]) == 2
+    names = [item["name"] for item in result["data"]]
+    assert "Alice Cooper" in names
+    assert "Frank Sinatra" in names
+
+
+@pytest.mark.asyncio
+async def test_not_filter_with_multiple_like_values_sqlmodel(async_session, test_model):
+    """Test NOT filter with multiple values for the same operator - SQLModel version"""
+    test_data = [
+        {"name": "Alice Johnson", "tier_id": 1, "category_id": 1},
+        {"name": "Bob Smith", "tier_id": 2, "category_id": 1},
+        {"name": "Charlie Brown", "tier_id": 3, "category_id": 2},
+        {"name": "David Jones", "tier_id": 4, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Test NOT filter with multiple like patterns
+    result = await crud.get_multi(async_session, name__not={"like": ["Alice%", "Bob%"]})
+
+    assert len(result["data"]) == 2
+    names = [item["name"] for item in result["data"]]
+    assert "Charlie Brown" in names
+    assert "David Jones" in names
+    assert "Alice Johnson" not in names
+    assert "Bob Smith" not in names
+
+
+@pytest.mark.asyncio
+async def test_combined_filters_with_list_or_sqlmodel(async_session, test_model):
+    """Test combining regular filters with list-based OR filters - SQLModel version"""
+    test_data = [
+        {"name": "Alice Johnson", "tier_id": 1, "category_id": 1},
+        {"name": "Alice Cooper", "tier_id": 2, "category_id": 2},
+        {"name": "Bob Smith", "tier_id": 3, "category_id": 1},
+        {"name": "Frank Miller", "tier_id": 4, "category_id": 1},
+        {"name": "Frank Sinatra", "tier_id": 5, "category_id": 2},
+    ]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    # Combine regular filter with list-based OR filter
+    result = await crud.get_multi(
+        async_session,
+        category_id=1,  # AND condition
+        name__or={"like": ["Alice%", "Frank%"]},  # OR condition with list
+    )
+
+    assert len(result["data"]) == 2
+    for item in result["data"]:
+        assert item["category_id"] == 1
+        assert item["name"].startswith("Alice") or item["name"].startswith("Frank")
+
+    names = [item["name"] for item in result["data"]]
+    assert "Alice Johnson" in names
+    assert "Frank Miller" in names
+    assert "Alice Cooper" not in names  # category_id=2
+    assert "Frank Sinatra" not in names  # category_id=2


### PR DESCRIPTION
# Pull Request: Support Multiple Values for Same Operator in OR/NOT Filters

## Description
This PR adds support for using multiple values with the same operator in `__or` and `__not` filters. This allows more flexible filtering patterns, particularly useful for matching multiple LIKE patterns on the same field.

## Changes
- Enhanced `_handle_or_filter` method to accept lists of values for operators
- Enhanced `_handle_not_filter` method to accept lists of values for operators  
- Fixed existing tests that had duplicate dictionary keys (invalid Python syntax)
- Added comprehensive test coverage for the new feature
- Updated documentation with examples of the new syntax

Related to filtering enhancement requests for more flexible OR conditions.

## Tests
- Added `tests/sqlalchemy/crud/test_multiple_like_or.py` with 6 test cases covering:
  - Multiple LIKE patterns with OR
  - Multiple values with NOT filters
  - Mixing list and single values
  - Combined filters with list-based OR
- Added `tests/sqlmodel/crud/test_multiple_like_or.py` for SQLModel compatibility
- Added `test_get_multi_or_filtering` and `test_get_multi_not_filtering` to SQLModel test suite
- Fixed existing tests in `test_get_multi.py` that had duplicate dictionary keys

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.

## Additional Notes

### New Syntax Examples:
```python
# Multiple LIKE patterns (OR logic)
await crud.get_multi(
    db,
    name__or={"like": ["Alice%", "Frank%", "Bob%"]}
)
# Generates: WHERE name LIKE 'Alice%' OR name LIKE 'Frank%' OR name LIKE 'Bob%'

# Multiple patterns with NOT
await crud.get_multi(
    db, 
    name__not={"like": ["Test%", "Admin%"]}
)
# Generates: WHERE NOT (name LIKE 'Test%') AND NOT (name LIKE 'Admin%')

# Mix list and single values
await crud.get_multi(
    db,
    name__or={
        "like": ["Alice%", "Frank%"],  # List of patterns
        "startswith": "Bob"             # Single value
    }
)
```

### Backward Compatibility:
- Fully backward compatible - existing code continues to work
- Single values still work as before
- Only adds new capability when a list is provided

### Testing:
- All existing tests pass
- Ruff and mypy checks pass
- Tested with both SQLAlchemy and SQLModel